### PR TITLE
RANCHER-2320: Fix workflow parameters to match platform expectations

### DIFF
--- a/.github/workflows/app-release-preparation.yml
+++ b/.github/workflows/app-release-preparation.yml
@@ -1,13 +1,10 @@
-name: Application Release Preparation
+name: Application Release Branch Preparation
+
+run-name: Application Release Branch Preparation [${{ inputs.dispatch_id }}]
 
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: 'Perform dry run without making changes'
-        required: false
-        type: boolean
-        default: false
       previous_release_branch:
         description: 'Previous release branch (e.g., R1-2024)'
         required: true
@@ -16,20 +13,39 @@ on:
         description: 'New release branch (e.g., R2-2024)'
         required: true
         type: string
-      use_snapshot_version:
+      use_snapshot_fallback:
         description: 'Use snapshot branch as fallback if previous release branch not found'
         required: false
         type: boolean
         default: false
+      use_snapshot_version:
+        description: 'Use snapshot version as a base version'
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Perform dry run without making changes'
+        required: false
+        type: boolean
+        default: false
+      dispatch_id:
+        description: 'Unique identifier for workflow tracking'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
 
 jobs:
   prepare-app-release:
-    name: Prepare app-eholdings Release
+    name: Prepare Application Release
     uses: folio-org/kitfox-github/.github/workflows/app-release-preparation.yml@master
     with:
-      app_name: app-eholdings
+      app_name: ${{ github.repository }}
       previous_release_branch: ${{ inputs.previous_release_branch }}
       new_release_branch: ${{ inputs.new_release_branch }}
+      use_snapshot_fallback: ${{ inputs.use_snapshot_fallback }}
       use_snapshot_version: ${{ inputs.use_snapshot_version }}
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
@@ -37,10 +53,17 @@ jobs:
   slack_notification:
     name: Slack Notification
     needs: prepare-app-release
-    if: always() && inputs.dry_run == false
+    if: always() && inputs.dry_run == false && vars.SLACK_NOTIF_CHANNEL != ''
     uses: folio-org/kitfox-github/.github/workflows/app-release-preparation-notification.yml@master
     with:
-      app_name: app-eholdings
-      status: ${{ needs.prepare-app-release.result }}
+      app_name: ${{ github.repository }}
+      new_release_branch: ${{ inputs.new_release_branch }}
+      source_branch: ${{ needs.prepare-app-release.outputs.source_branch }}
       app_version: ${{ needs.prepare-app-release.outputs.app_version }}
+      commit_sha: ${{ needs.prepare-app-release.outputs.commit_sha }}
+      workflow_result: ${{ needs.prepare-app-release.result }}
+      workflow_run_id: ${{ github.run_id }}
+      workflow_run_number: ${{ github.run_number }}
+      slack_notif_channel: ${{ vars.SLACK_NOTIF_CHANNEL }}
     secrets: inherit
+


### PR DESCRIPTION
Fixes HTTP 422 error: "Unexpected inputs provided: ["dispatch_id", "use_snapshot_fallback"]"

Added missing parameters to match app-acquisitions workflow:
- use_snapshot_fallback parameter
- dispatch_id parameter for tracking
- Updated job configuration

Resolves platform release-preparation workflow failure.